### PR TITLE
Added support for users.info api request

### DIFF
--- a/src/Core/Commander.php
+++ b/src/Core/Commander.php
@@ -197,6 +197,10 @@ class Commander {
             'token'    => true,
             'endpoint' => '/stars.list'
         ],
+        'users.info' => [
+            'token'    => true,
+            'endpoint' => '/users.info'
+        ],
         'users.list' => [
             'token'    => true,
             'endpoint' => '/users.list'


### PR DESCRIPTION
The list of commands was missing the users.info command (seen here: https://api.slack.com/methods/users.info)

Just added it to the list of recognised commands that it knows what to do with.
