### PR TITLE
chat.postMessage to POST Method

### DIFF
--- a/src/Core/Commander.php
+++ b/src/Core/Commander.php
@@ -94,6 +94,7 @@ class Commander {
         ],
         'chat.postMessage' => [
             'token'    => true,
+            'post'     => true, 
             'endpoint' => '/chat.postMessage',
             'format'   => [
                 'text',
@@ -474,6 +475,8 @@ class Commander {
 
         $url = self::$baseUrl . $command['endpoint'];
 
+        $headers = array_merge($headers, ['Authorization' => 'Bearer ' . $this->token]);
+        
         if (isset($command['post']) && $command['post'])
             return $this->interactor->post($url, [], $parameters, $headers);
 


### PR DESCRIPTION
In Slack the method 'chat.postmessage' is being sent by "get" when it should be for "post".

[https://api.slack.com/methods/chat.postMessage](https://api.slack.com/methods/chat.postMessage)


In addition, the Slack documentation says that the authorization method should go to the Token in the Header.
[https://api.slack.com/legacy/oauth#authenticating-users-with-oauth__using-access-tokens](https://api.slack.com/legacy/oauth#authenticating-users-with-oauth__using-access-tokens)